### PR TITLE
changed  the command "pub get"  to "dart pub get"

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Also make sure to grab the dependencies first:
 
 ```bash
 cd path/to/github-tracker
-pub get
+dart pub get
 ```
 
 You can get help on the available commands by running:


### PR DESCRIPTION
the standalone "pub" command is deprecated.

 source https://dart.dev/tools/pub/cmd