### PR TITLE
Declare `nvbn/thefuck` a software repo

### DIFF
--- a/lib/contentRepos.dart
+++ b/lib/contentRepos.dart
@@ -20,7 +20,6 @@ const List contentRepos = [
   'h5bp/html5-boilerplate',
   'toddmotto/public-apis',
   'resume/resume.github.com',
-  'nvbn/thefuck',
   'h5bp/Front-end-Developer-Interview-Questions',
   'jlevy/the-art-of-command-line',
   'google/material-design-icons',


### PR DESCRIPTION
@timsneath I would argue that is very clearly a **software repo**: https://github.com/nvbn/thefuck

It even has full test coverage.

I decided to separate this from #9 as this one might be more "controversial" and the ones in #9 are clearly *added* content repos.